### PR TITLE
Tideways Package

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -22,6 +22,7 @@ source $bp_dir/bin/util/common.sh
 # for extensions that need special treatment
 source $bp_dir/bin/util/newrelic.sh
 source $bp_dir/bin/util/blackfire.sh
+source $bp_dir/bin/util/tideways.sh
 
 # if this is set it prevents Git clones (e.g. for Composer installs from source) during the build in some circumstances, and it is set in SSH Git deploys to Heroku
 unset GIT_DIR
@@ -349,3 +350,4 @@ install_blackfire_ext
 # special treatment for New Relic; we enable it if we detect a license key for it
 install_newrelic_ext
 install_newrelic_userini
+install_tideways_ext

--- a/bin/util/tideways.sh
+++ b/bin/util/tideways.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+install_tideways_ext() {
+    # we enable Tideways when we detect the TIDEWAYS_APIKEY environment variable.
+    TIDEWAYS_APIKEY=${TIDEWAYS_APIKEY:-}
+    if [[ "$engine" == "php" && -n "$TIDEWAYS_APIKEY" ]] && ! $engine $(which composer) show -d "$build_dir/.heroku/php" --installed --quiet heroku-sys/ext-tideways; then
+        if $engine -n $(which composer) require --quiet --update-no-dev -d "$build_dir/.heroku/php" -- "heroku-sys/ext-tideways:*"; then
+            echo "- Tideways detected, installed ext-tideways" | indent
+        else
+            warning_inline "Tideways detected, but no suitable extension available"
+        fi
+    fi
+}

--- a/support/build/extensions/no-debug-non-zts-20121212/tideways
+++ b/support/build/extensions/no-debug-non-zts-20121212/tideways
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/php
+
+OUT_PREFIX=$1
+
+# fail hard
+set -o pipefail
+# fail harder
+set -eu
+
+source $(dirname $BASH_SOURCE)/../../_util/include/manifest.sh
+
+ZEND_MODULE_API_VERSION=$(basename $(dirname $0))
+ZEND_MODULE_API_VERSION=${ZEND_MODULE_API_VERSION#no-debug-non-zts-}
+
+case ${ZEND_MODULE_API_VERSION} in
+    20121212)
+        series=5.5
+        ;;
+    20131226)
+        series=5.6
+        ;;
+    20151012)
+        series=7.0
+        ;;
+    *)
+        echo "Unsupported PHP/Zend Module API version: ${ZEND_MODULE_API_VERSION}"
+        exit 1
+        ;;
+esac
+
+ext_dir=${OUT_PREFIX}/lib/php/extensions/no-debug-non-zts-${ZEND_MODULE_API_VERSION}
+bin_dir=${OUT_PREFIX}/bin
+
+dep_formula=${0#$WORKSPACE_DIR/}
+dep_name=$(basename $BASH_SOURCE)
+dep_version=${VERSION}
+dep_package=ext-${dep_name}-${dep_version}
+dep_manifest=${dep_package}_php-$series.composer.json
+
+echo "-----> Packaging ${dep_package}..."
+
+wget -O tideways.tar.gz https://s3-eu-west-1.amazonaws.com/qafoo-profiler/heroku/tideways-heroku-${VERSION}-php-${series}.tar.gz
+
+tar -zxf tideways.tar.gz
+
+mkdir -p ${OUT_PREFIX}/bin
+mkdir -p ${OUT_PREFIX}/var/tideways/run
+cat > ${OUT_PREFIX}/bin/profile.tideways.sh <<'EOF'
+if [[ -n "$TIDEWAYS_APIKEY" ]]; then
+    if [[ -f "/app/.heroku/php/bin/tideways-daemon" ]]; then
+        /app/.heroku/php/bin/tideways-daemon -socket="/app/.heroku/php/var/tideways/run/tidewaysd.sock" &
+    else
+        echo >&2 "WARNING: Add-on 'tideways' detected, but PHP extension not yet installed. Push an update to the application to finish installation of the add-on; an empty change ('git commit --allow-empty') is sufficient."
+    fi
+fi
+EOF
+mkdir -p ${OUT_PREFIX}/etc/php/conf.d
+cat > ${OUT_PREFIX}/etc/php/conf.d/tideways.ini-dist <<'EOF'
+extension=tideways.so
+tideways.connection=unix:///app/.heroku/php/var/tideways/run/tidewaysd.sock
+EOF
+
+MANIFEST_REQUIRE="${MANIFEST_REQUIRE:-"{\"heroku-sys/php\":\"${series}.*\"}"}"
+MANIFEST_CONFLICT="${MANIFEST_CONFLICT:-"{\"heroku-sys/hhvm\":\"*\"}"}"
+MANIFEST_EXTRA="${MANIFEST_EXTRA:-"{\"config\":\"etc/php/conf.d/tideways.ini-dist\",\"profile\":\"bin/profile.tideways.sh\"}"}"
+MANIFEST_REPLACE="${MANIFEST_REPLACE:-"{}"}"
+
+python $(dirname $BASH_SOURCE)/../../_util/include/manifest.py "heroku-sys-php-extension" "heroku-sys/ext-${dep_name}" "$dep_version" "${dep_formula}.tar.gz" "$MANIFEST_REQUIRE" "$MANIFEST_CONFLICT" "$MANIFEST_REPLACE" "$MANIFEST_EXTRA" > $dep_manifest
+
+print_or_export_manifest_cmd "$(generate_manifest_cmd "$dep_manifest")"

--- a/support/build/extensions/no-debug-non-zts-20121212/tideways
+++ b/support/build/extensions/no-debug-non-zts-20121212/tideways
@@ -44,23 +44,6 @@ wget -O tideways.tar.gz https://s3-eu-west-1.amazonaws.com/qafoo-profiler/heroku
 
 tar -zxf tideways.tar.gz
 
-mkdir -p ${OUT_PREFIX}/bin
-mkdir -p ${OUT_PREFIX}/var/tideways/run
-cat > ${OUT_PREFIX}/bin/profile.tideways.sh <<'EOF'
-if [[ -n "$TIDEWAYS_APIKEY" ]]; then
-    if [[ -f "/app/.heroku/php/bin/tideways-daemon" ]]; then
-        /app/.heroku/php/bin/tideways-daemon -socket="/app/.heroku/php/var/tideways/run/tidewaysd.sock" &
-    else
-        echo >&2 "WARNING: Add-on 'tideways' detected, but PHP extension not yet installed. Push an update to the application to finish installation of the add-on; an empty change ('git commit --allow-empty') is sufficient."
-    fi
-fi
-EOF
-mkdir -p ${OUT_PREFIX}/etc/php/conf.d
-cat > ${OUT_PREFIX}/etc/php/conf.d/tideways.ini-dist <<'EOF'
-extension=tideways.so
-tideways.connection=unix:///app/.heroku/php/var/tideways/run/tidewaysd.sock
-EOF
-
 MANIFEST_REQUIRE="${MANIFEST_REQUIRE:-"{\"heroku-sys/php\":\"${series}.*\"}"}"
 MANIFEST_CONFLICT="${MANIFEST_CONFLICT:-"{\"heroku-sys/hhvm\":\"*\"}"}"
 MANIFEST_EXTRA="${MANIFEST_EXTRA:-"{\"config\":\"etc/php/conf.d/tideways.ini-dist\",\"profile\":\"bin/profile.tideways.sh\"}"}"

--- a/support/build/extensions/no-debug-non-zts-20121212/tideways-4.0.3
+++ b/support/build/extensions/no-debug-non-zts-20121212/tideways-4.0.3
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/php
+
+FORMULA_FILE=$(basename $0)
+VERSION=${FORMULA_FILE/"tideways-"/""}
+
+source $(dirname $0)/tideways

--- a/support/build/extensions/no-debug-non-zts-20131226/tideways-4.0.3
+++ b/support/build/extensions/no-debug-non-zts-20131226/tideways-4.0.3
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/php/
+
+FORMULA_FILE=$(basename $0)
+VERSION=${FORMULA_FILE/"tideways-"/""}
+
+source $(dirname $0)/../no-debug-non-zts-20121212/tideways-${VERSION}
+

--- a/support/build/extensions/no-debug-non-zts-20151012/tideways-4.0.3
+++ b/support/build/extensions/no-debug-non-zts-20151012/tideways-4.0.3
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Build Path: /app/.heroku/php/
+
+FORMULA_FILE=$(basename $0)
+VERSION=${FORMULA_FILE/"tideways-"/""}
+
+source $(dirname $0)/../no-debug-non-zts-20121212/tideways-${VERSION}


### PR DESCRIPTION
Integrates with new way of building Heroku extension packages.

No testing done yet, my heroku toolbelt fails miserably with `Error: Cannot find module 'heroku-pipelines'` and that is even more code is in support/build, its hard to setup.

Essentially everything can be tested already by using `dzuelke/heroku-buildpack-php#develop` and the following composer.json, but b/c of toolbelt problems i cannot test this as well.

```
{
    "name": "tideways/heroku-test",
    "require": {
        "php": "5.6.*",
        "ext-tideways": "@stable"
    },
    "repositories": [
        {"type": "composer", "url": "https://s3-eu-west-1.amazonaws.com/qafoo-profiler/heroku/packages.json"}
    ]
}
```

It is using Tideways PHP extension 4.0.3 which has PHP 7 support and defines a `profile` and `config` extra keys which are handled by Heroku Intaller v1.1+

Pushing to my old test app this gives the following error:

```
remote: Compressing source files... done.
remote: Building source:
remote: 
remote: -----> Fetching set buildpack https://github.com/dzuelke/heroku-buildpack-php#develop... done
remote: -----> PHP app detected
remote: -----> Bootstrapping...
remote: -----> Installing platform packages...
remote: 
remote:  !     ERROR: Failed to install system packages.
remote:        
remote:        Your platform requirements (for runtimes and extensions) could
remote:        not be resolved to an installable set of dependencies, or a
remote:        repository was unreachable.
remote:        
remote:        Full error information from installation attempt:
remote:        
remote:        > Loading repositories with available runtimes and extensions
remote:        > 
remote:        > Your requirements could not be resolved to an installable set of packages.
remote:        > 
remote:        >   Problem 1
remote:        >     - Installation request for composer.json/composer.lock dev-f18f42433b871b00e39380be6b08ba2d -> satisfiable by composer.json/composer.lock[dev-f18f42433b871b00e39380be6b08ba2d].
remote:        >     - composer.json/composer.lock dev-f18f42433b871b00e39380be6b08ba2d requires ext-tideways @stable -> no matching package found.
remote:        > 
remote:        
remote:        Please verify that all requirements for runtime versions in
remote:        'composer.lock' are compatible with the list below, and ensure
remote:        all required extensions are available for the desired runtimes.
remote:        
remote:        For reference, the following runtimes are currently available:
remote:        
remote:        PHP:  7.0.3, 7.0.2, 7.0.1, 7.0.0, 5.6.18, 5.6.17, 5.6.16, 
remote:        5.5.32, 5.5.31, 5.5.30
remote:        HHVM: 3.5.1
remote:        
remote:        For a list of supported runtimes & extensions on Heroku, please
remote:        refer to: https://devcenter.heroku.com/articles/php-support
remote: 
remote: 
remote:  !     Push rejected, failed to compile PHP app
remote: 
remote: Verifying deploy...
remote: 
remote: !   Push rejected to gentle-beach-9886.
remote: 
To https://git.heroku.com/gentle-beach-9886.git
```
